### PR TITLE
Add CLI option to auto-start tunnels by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/sio2boss/tunnel9/main/to
 - Real-time monitoring of tunnel performance (throughput and latency)
 - Support for bastion/jump host configurations
 - Tag-based organization and filtering
+- Optional auto-start of tunnels by tag via CLI
 - Column-based sorting and organization
 
 ## Architecture Haiku
@@ -64,6 +65,11 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/sio2boss/tunnel9/main/to
 - YAML for configuration (`gopkg.in/yaml.v3`)
 
 ## Interface
+
+## Command Line Options
+
+- `--config=<path>` – Override the configuration file path.
+- `--auto-start=<tags>` – Comma-separated list of tags to start automatically on launch. Use `all` to start every configured tunnel.
 
 ### Controls
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"tunnel9/internal/config"
@@ -19,12 +20,13 @@ const USAGE_CONTENT string = `tunnel9 - SSH Tunnel Manager
 Version: %s
 
 Usage:
-  tunnel9 [--config=<path>]
+  tunnel9 [--config=<path>] [--auto-start=<tags>]
   tunnel9 -h | --help
 
 Options:
   -h --help        Show this screen.
-  --config=<path>  Path to config file [default: ~/.local/state/tunnel9/config.yaml]`
+  --config=<path>  Path to config file [default: ~/.local/state/tunnel9/config.yaml]
+  --auto-start=<tags>  Comma-separated list of tags to auto-start (use "all" for every tunnel)`
 
 func main() {
 	usage := fmt.Sprintf(USAGE_CONTENT, VERSION)
@@ -56,7 +58,22 @@ func main() {
 		time.Sleep(2 * time.Second)
 	}
 
-	app := ui.NewApp(loader, tunnels)
+	autoStartRaw := ""
+	if raw, ok := opts["--auto-start"].(string); ok {
+		autoStartRaw = raw
+	}
+
+	var autoStartTags []string
+	if autoStartRaw != "" {
+		for _, tag := range strings.Split(autoStartRaw, ",") {
+			trimmed := strings.TrimSpace(tag)
+			if trimmed != "" {
+				autoStartTags = append(autoStartTags, trimmed)
+			}
+		}
+	}
+
+	app := ui.NewApp(loader, tunnels, autoStartTags)
 	p := tea.NewProgram(
 		app,
 		tea.WithAltScreen(), // Use alternate screen buffer


### PR DESCRIPTION
## Summary
- add a `--auto-start` CLI option that accepts comma-separated tags or `all`
- automatically start matching tunnels during application initialization
- document the new option in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68ceb79350f48331a8b0d51efc21b092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CLI support for auto-starting tunnels by tag using --auto-start=<tags> (use all to start every configured tunnel).
- Documentation
  - Updated Features section to mention optional auto-start of tunnels via CLI.
  - Added a Command Line Options section describing:
    - --config=<path> to override the configuration file path.
    - --auto-start=<tags> to start tagged tunnels automatically on launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->